### PR TITLE
Improve three-level plotting documentation with simulated example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
     haven,
     lme4,
     lmerTest,
+    plotly,
     purrr,
     rlang,
     scales,


### PR DESCRIPTION
## Summary
- add a fully worked simulation-based example to `plot_glmm_three_level()` documentation to demonstrate three-level usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e006f1a0f483229b8c10f80d7726d5