### PR TITLE
Fix level label mapping in three-level plot

### DIFF
--- a/R/plot_glmm_three_level.R
+++ b/R/plot_glmm_three_level.R
@@ -217,10 +217,10 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
   pred_grid <- pred_grid |>
     dplyr::mutate(
       Prediction = transform_eta(Eta, family, y_scale),
-      level2_index = as.numeric(.data[[level2_var]]),
-      predictor_value = .data[[predictor]],
-      level2_label = .data[[level2_var]],
-      level3_label = .data[[level3_var]],
+      level2_label = !!level2_sym,
+      level3_label = !!level3_sym,
+      level2_index = as.numeric(level2_label),
+      predictor_value = !!predictor_sym,
       custom_level2 = as.character(level2_label),
       custom_level3 = as.character(level3_label),
       hover_template = paste0(


### PR DESCRIPTION
## Summary
- ensure the three-level plotting helper derives grouping labels using tidy evaluation so that color mapping works with arbitrary variable names

## Testing
- not run (R not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e01227838c8322ada6495ed249dfe5