### PR TITLE
Fix plotly inheritance issue in three-level GLMM plot

### DIFF
--- a/R/plot_glmm_three_level.R
+++ b/R/plot_glmm_three_level.R
@@ -307,7 +307,8 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
       line = list(color = "#000000", width = line_width + 1),
       hoverinfo = "text",
       hovertemplate = ~hover_template,
-      showlegend = TRUE
+      showlegend = TRUE,
+      inherit = FALSE
     ) |>
     plotly::layout(
       title = plot_title,


### PR DESCRIPTION
## Summary
- prevent the mean trajectory trace from inheriting aesthetics that require level-3 labels
- ensure the example three-level plot renders without missing column errors

## Testing
- Not run (R is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e569bca5348322814f13445b7f2245