### PR TITLE
Separate classroom trajectories in three-level GLMM plot

### DIFF
--- a/R/plot_glmm_three_level.R
+++ b/R/plot_glmm_three_level.R
@@ -162,6 +162,11 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
     )
   }
 
+  nesting <- nesting |>
+    dplyr::group_by(!!level3_sym) |>
+    dplyr::mutate(show_level3_legend = dplyr::row_number() == 1) |>
+    dplyr::ungroup()
+
   n_predictor <- length(predictor_seq)
   n_groups <- nrow(nesting)
 
@@ -238,6 +243,7 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
       predictor_value = .data[[predictor]],
       custom_level2 = as.character(level2_label),
       custom_level3 = as.character(level3_label),
+      trace_id = as.character(interaction(level3_label, level2_label, drop = TRUE)),
       hover_template = paste0(
         level3_var, ": ", custom_level3, "<br>",
         level2_var, ": ", custom_level2, "<br>",
@@ -287,6 +293,7 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
     x = ~predictor_value,
     y = ~level2_index,
     z = ~Prediction,
+    split = ~trace_id,
     color = ~level3_label,
     colors = colors,
     type = "scatter3d",
@@ -294,7 +301,10 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
     line = list(width = line_width),
     text = ~hover_template,
     hoverinfo = "text",
-    hovertemplate = ~hover_template
+    hovertemplate = ~hover_template,
+    legendgroup = ~level3_label,
+    name = ~level3_label,
+    showlegend = ~show_level3_legend
   ) |>
     plotly::add_trace(
       data = mean_line,
@@ -307,7 +317,8 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
       line = list(color = "#000000", width = line_width + 1),
       hoverinfo = "text",
       hovertemplate = ~hover_template,
-      showlegend = TRUE
+      showlegend = TRUE,
+      inherit = FALSE
     ) |>
     plotly::layout(
       title = plot_title,


### PR DESCRIPTION
## Summary
- ensure the three-level plot generates a distinct trace for each level-2 cluster so lines no longer connect across classrooms
- preserve a single legend entry per level-3 cluster while splitting traces

## Testing
- Not run (R is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e569bca5348322814f13445b7f2245