### PR TITLE
Fix duplicate legend entries in three-level plot

### DIFF
--- a/R/plot_glmm_three_level.R
+++ b/R/plot_glmm_three_level.R
@@ -302,6 +302,7 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
     text = ~hover_template,
     hoverinfo = "text",
     hovertemplate = ~hover_template,
+    showlegend = ~show_level3_legend,
     legendgroup = ~level3_label,
     name = ~level3_label
   ) |>
@@ -328,23 +329,6 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
         zaxis = axis_z
       )
     )
-
-  if (!is.null(plot_obj$x$data)) {
-    seen_groups <- character()
-    for (i in seq_along(plot_obj$x$data)) {
-      trace <- plot_obj$x$data[[i]]
-      if (!is.null(trace$legendgroup)) {
-        group <- trace$legendgroup
-        if (group %in% seen_groups) {
-          trace$showlegend <- FALSE
-        } else {
-          trace$showlegend <- TRUE
-          seen_groups <- c(seen_groups, group)
-        }
-        plot_obj$x$data[[i]] <- trace
-      }
-    }
-  }
 
   plot_obj
 }


### PR DESCRIPTION
## Summary
- ensure only one legend entry per third-level grouping by wiring the `show_level3_legend` flag directly into the plotly trace
- remove manual legend deduplication loop now that traces manage their own legend visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57aa36c58832290c4ad07e23f6b4d