### PR TITLE
Ensure three-level plot builds widget before legend dedupe

### DIFF
--- a/R/plot_glmm_three_level.R
+++ b/R/plot_glmm_three_level.R
@@ -329,22 +329,36 @@ plot_glmm_three_level <- function(model, data, predictor, outcome,
       )
     )
 
-  if (!is.null(plot_obj$x$data)) {
+  built_plot <- plotly::plotly_build(plot_obj)
+
+  if (!is.null(built_plot$x$data)) {
     seen_groups <- character()
-    for (i in seq_along(plot_obj$x$data)) {
-      trace <- plot_obj$x$data[[i]]
+    for (i in seq_along(built_plot$x$data)) {
+      trace <- built_plot$x$data[[i]]
       if (!is.null(trace$legendgroup)) {
         group <- trace$legendgroup
+        if (length(group) == 0) {
+          next
+        }
+
+        group <- group[1]
+        trace$legendgroup <- group
+
+        if (!is.null(trace$name)) {
+          trace$name <- trace$name[1]
+        }
+
         if (group %in% seen_groups) {
           trace$showlegend <- FALSE
         } else {
           trace$showlegend <- TRUE
           seen_groups <- c(seen_groups, group)
         }
-        plot_obj$x$data[[i]] <- trace
+
+        built_plot$x$data[[i]] <- trace
       }
     }
   }
 
-  plot_obj
+  built_plot
 }


### PR DESCRIPTION
## Summary
- build the plotly widget prior to legend deduplication so post-processing works on the constructed traces
- return the built widget after suppressing duplicate legend entries for level-3 groups

## Testing
- not run (package changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e57aa36c58832290c4ad07e23f6b4d